### PR TITLE
Add contribution and general structural documents for the project

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,46 @@
+# Contributing to the YANG Confluent Schema Registry plugin
+
+The Swisscom team, in collaboration with researchers and the IETF task group, has developed a plugin to support the YANG specs [RFC7950](https://datatracker.ietf.org/doc/html/rfc7950)
+for network data modeling into Confluent Schema Registry.
+
+> YANG is a data modeling language used to model configuration data, state data, Remote Procedure Calls, and notifications for network management protocols.
+
+_from RFC7950_
+
+## First Things First
+
+1. **When in doubt, open an issue** - For almost any type of contribution, the first step is opening an issue. 
+Even if you think you already know what the solution is, writing down a description of the problem you're trying to 
+solve will help everyone get context when they review your pull request. 
+
+2. **Only submit your own work**  (or work you have sufficient rights to submit) -
+
+3. When you're ready to start, we have see the next section for a contribution guide.
+
+## How to contribute
+
+Contributing to the YANG plugin for Confluent Schema Registry is a simple process.
+
+1. As a Software Engineer interested in contributing to the YANG plugins, you will fork the repository.
+2. Following that, you will clone the fork and work on your changes in your local copy of the code base.
+3. Once the changes are complete,  you will [open a pull request](../../pulls) to start the change submission process.
+
+After the pull request has landed a set of automated tests are going to be run, checking for potential security problems,
+as well as a good coding style. 
+
+4. A review, from the maintenance team, is going to follow with a review. 
+Contributors are expected to work on the feedback before the pull request could be accepted.
+5. Once the pull request gets accepted, the changes are going to be merge into the main project branch and be part of the next release.
+
+
+### Have an Idea or Feature Request, Got a Question or just wanna Learn?
+
+Have a problem you want the Kafka health API to solve for you?
+
+* Please [open an issue on our GitHub page](../../issues)
+
+### Something Not Working? Found a Bug? or a Security Issue?
+
+If you think you found a bug, it probably is a bug.
+
+* File it [on our GitHub page](../../issues)

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,14 @@
+- [Overview](#overview)
+- [Current Maintainers](#current-maintainers)
+
+## Overview
+
+This document contains a list of maintainers in this repo. 
+If you're interested in contributing, see [CONTRIBUTING](CONTRIBUTING.md).
+
+## Current Maintainers
+
+| Maintainer | GitHub ID                                                 | Affiliation |
+|  | --------------------------------------------------------- | ----------- |
+| XXXX | [XXXX](https://github.com/XXXX)                   | XXXX      |
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-This repo is to support Yang data format. 
+# YANG format plugin for Confluent Schema Registry
+
+The Swisscom team, in collaboration with researchers and the IETF task group, has developed a plugin to support the YANG specs [RFC7950](https://datatracker.ietf.org/doc/html/rfc7950)
+for network data modeling into Confluent Schema Registry.
+
+> YANG is a data modeling language used to model configuration data, state data, Remote Procedure Calls, and notifications for network management protocols.
+
+_from RFC7950_
+
+## How to contribute
+
+The YANG plugin has been created using an open source license, the project team welcome contributions of any kind. 
+To get yourself started for a contribution please check the [guide](CONTRIBUTING.md) available in this repo.
+
+## Building the project
+
+TBA
+
+## Using the plugin in your Schema Registry
+TBA
+
+## License
+This project is under the [Apache 2.0 License](LICENSE).


### PR DESCRIPTION
Added an initial version for a few general docs in the project governance:

* Added a contributors guideline doc.
* Add a place to list and structure the maintainers
* Updated and provided a bit of organisation to the project general readme.